### PR TITLE
More testing

### DIFF
--- a/Runtime/Commands/CommandStream.cs
+++ b/Runtime/Commands/CommandStream.cs
@@ -106,12 +106,24 @@ namespace SadSapphicGames.CommandPattern
             }
         }
         /// <summary>
-        /// This will remove all commands from the CommandStream's queue and replace it with a new empty queue. THIS DOES NOT EXECUTE COMMANDS.
+        /// This will remove all commands from the CommandStream's queue and replace it with a new empty queue.
         /// </summary>
-        /// <returns> The commands in the previous queue, in case this information is needed (for example to rearrange an requeue them).</returns>
-        public List<Command> EmptyQueue(){
+        /// <remark> This can be useful to rearrange the commands in a queue. Simple preform the needed changes on the returned list and re-queue it </remark>
+        /// <returns> The commands in the previous queue, in case this information is needed.</returns>
+        public List<Command> DropQueue() {
             var output = commandQueue.ToList();
             commandQueue = new Queue<Command>();
+            return output;
+        }
+        /// <summary>
+        /// This will remove all commands from the CommandStream's history and replace it with a new empty list.
+        /// </summary>
+        /// <remark> This can be useful if you need the CommandStream to record all of its history but also need it to execute an extremely large number of commands without running out of memory. Even if every command is the same object a CommandStream will run out of memory at 2-3 hundred million commands in its queue or history. </remark>
+        /// <returns> The commands in the previous history, in case this information is needed </returns>
+        public ReadOnlyCollection<Command> DropHistory() {
+            var output = GetCommandHistory();
+            commandHistory = new List<Command>();
+            historyStartIndex = 0;
             return output;
         }
         private void RecordCommand(Command command) {
@@ -128,15 +140,7 @@ namespace SadSapphicGames.CommandPattern
                 throw new Exception("Recorded history has exceeded maximum history depth");
             }
         }
-        // private void DropOldCommandHistory() {
-        //     if (HistoryCount <= HistoryDepth) {
-        //         Debug.LogWarning("attempting to drop history when history count is less or equal to than maximum depth");
-        //         return;
-        //     }
-        //     int commandsToDrop = (int)(HistoryCount - HistoryDepth);
-        //     commandHistory.RemoveRange(0, commandsToDrop);
-        //     //? O(HistoryCount)
-        // }
+
         /// <summary>
         /// Attempt to queue's the undo command of a Command object implementing IUndoable if that command exists in this CommandStream's history
         /// </summary>

--- a/Tests/EditorTests/CommandStreamTests.cs
+++ b/Tests/EditorTests/CommandStreamTests.cs
@@ -94,6 +94,18 @@ public class CommandStreamTests {
 
     }
     [Test]
+    public void DropHistoryTest() {
+        CommandStream commandStream = new CommandStream();
+        var testCommand = new NullCommand();
+        commandStream.QueueCommand(testCommand);
+        Assert.IsTrue(commandStream.TryExecuteNext());
+        var oldHistory = commandStream.DropHistory();
+        Assert.AreEqual(expected: 0, actual: commandStream.HistoryCount);
+        Assert.AreEqual(expected: 1, actual: oldHistory.Count);
+        Assert.AreEqual(expected: testCommand, actual: oldHistory[0]);
+
+    }
+    [Test]
     public void ExecuteFullQueueNoFailureTest() {
         int testLength = 10;
         CommandStream commandStream = new CommandStream();

--- a/Tests/EditorTests/CommandStreamTests.cs
+++ b/Tests/EditorTests/CommandStreamTests.cs
@@ -83,11 +83,11 @@ public class CommandStreamTests {
         }
     }
     [Test]
-    public void EmptyQueueTest() {
+    public void DropQueueTest() {
         CommandStream commandStream = new CommandStream();
         var testCommand = new NullCommand();
         commandStream.QueueCommand(testCommand);
-        var oldQueue = commandStream.EmptyQueue();
+        var oldQueue = commandStream.DropQueue();
         Assert.IsFalse(commandStream.TryExecuteNext());
         Assert.AreEqual(expected: 1, actual: oldQueue.Count);
         Assert.AreEqual(expected: testCommand, actual: oldQueue[0]);

--- a/Tests/EditorTests/IUndoableTest.cs
+++ b/Tests/EditorTests/IUndoableTest.cs
@@ -20,23 +20,23 @@ public class IUndoableTest
     }
     [Test]
     public void TryQueueUndoCommandTest() {
-        NullCommand testCommand = new NullCommand();
+        NullCommand testUndoableCommand = new NullCommand();
         CommandStream commandStream = new CommandStream(1);
         CommandStream commandStreamNoHistory = new CommandStream(0);
 
-        commandStreamNoHistory.QueueCommand(testCommand);
+        commandStreamNoHistory.QueueCommand(testUndoableCommand);
         Assert.IsTrue(commandStreamNoHistory.TryExecuteNext());
         //? Verify a CommandStream that doesnt record history will not let you use TryQueueUndo
-        Assert.IsFalse(commandStreamNoHistory.TryQueueUndoCommand(testCommand));
+        Assert.IsFalse(commandStreamNoHistory.TryQueueUndoCommand(testUndoableCommand));
 
         //? Verify if a CommandStream does not have a command anywhere it will not let you undo it
-        Assert.IsFalse(commandStream.TryQueueUndoCommand(testCommand));
-        commandStream.QueueCommand(testCommand);
+        Assert.IsFalse(commandStream.TryQueueUndoCommand(testUndoableCommand));
+        commandStream.QueueCommand(testUndoableCommand);
         //? Verify if a CommandStream has a command in its queue it will not let you undo it
-        Assert.IsFalse(commandStream.TryQueueUndoCommand(testCommand));
+        Assert.IsFalse(commandStream.TryQueueUndoCommand(testUndoableCommand));
         Assert.IsTrue(commandStream.TryExecuteNext());
         //? Verify if a CommandStream records a command in its history it will let you undo it
-        Assert.IsTrue(commandStream.TryQueueUndoCommand(testCommand));
+        Assert.IsTrue(commandStream.TryQueueUndoCommand(testUndoableCommand));
         //? Since the undo command was queued it should be able to be executed
         Assert.IsTrue(commandStream.TryExecuteNext());
         //? but after that the queue should be empty
@@ -46,6 +46,20 @@ public class IUndoableTest
         commandStream.QueueCommand(new NullCommand());
         Assert.IsTrue(commandStream.TryExecuteNext());
         //? Verify if a command has been pushed out of a CommandStreams history it will not let you undo it
-        Assert.IsFalse(commandStream.TryQueueUndoCommand(testCommand));
+        Assert.IsFalse(commandStream.TryQueueUndoCommand(testUndoableCommand));
+    }
+
+    [Test]
+    public void ForceUndoCommandTest(){
+        NullCommand testUndoableCommand = new NullCommand();
+        CommandStream testStreamNoHistory = new CommandStream(0);
+        Assert.IsFalse(testStreamNoHistory.TryQueueUndoCommand(testUndoableCommand));
+        testStreamNoHistory.ForceQueueUndoCommand(testUndoableCommand);
+        Assert.IsFalse(testStreamNoHistory.QueueEmpty);
+        Assert.IsTrue(testStreamNoHistory.TryExecuteNext(out var executedCommand));
+        Assert.AreEqual(
+            expected: testUndoableCommand.GetUndoCommand(),
+            actual: executedCommand
+        );
     }
 }

--- a/Tests/EditorTests/StressTests.cs
+++ b/Tests/EditorTests/StressTests.cs
@@ -65,4 +65,18 @@ public class StressTests_MayTakeLongToRun {
         Assert.IsTrue(commandStream.QueueEmpty);
         //? at one hundred million test takes ~10 seconds
     }
+    [Test, Timeout(300000)]
+    public void IntMaxCommandsCappedHistoryInLoopExecutionTest() {
+        //? As expected if the commands are executed as they are added to the queue and a limited number are recorded in history we don't run out of memory and this test will run given enough time  
+        int testLength = int.MaxValue;
+        int historyDepth = 100000000;
+        CommandStream commandStream = new CommandStream(historyDepth);
+        Debug.Log($"current test settings: execute {nameof(testNullCommand)} {testLength} times, history recorded to a depth of {historyDepth}, commands executed as they enter queue.");
+        for (int i = 0; i < testLength; i++) {
+            commandStream.QueueCommand(testNullCommand);
+            commandStream.TryExecuteNext();
+        }
+        Assert.IsTrue(commandStream.QueueEmpty);
+        //? Executes in ~100 seconds (less but that closest order of magnitude)
+    }
 }

--- a/Tests/EditorTests/StressTests.cs
+++ b/Tests/EditorTests/StressTests.cs
@@ -16,7 +16,7 @@ public class StressTests_MayTakeLongToRun {
         //? Test will run out of memory if length somewhere between 2 and 3 hundred million
         int testLength = 100000000;
         CommandStream commandStream = new CommandStream();
-        Debug.Log($"current test settings: execute {nameof(testNullCommand)} {testLength} times, records full history");
+        Debug.Log($"current test settings: execute {nameof(testNullCommand)} {testLength} times, records full history, commands executed once all are queued.");
         for (int i = 0; i < testLength; i++) {
             commandStream.QueueCommand(testNullCommand);
         }
@@ -29,7 +29,7 @@ public class StressTests_MayTakeLongToRun {
         //? Test will also run out of memory if length somewhere between 2 and 3 hundred million
         int testLength = 100000000;
         CommandStream commandStream = new CommandStream(0);
-        Debug.Log($"current test settings: execute {nameof(testNullCommand)} {testLength} times, no history recorded.");
+        Debug.Log($"current test settings: execute {nameof(testNullCommand)} {testLength} times, no history recorded, commands executed once all are queued.");
         for (int i = 0; i < testLength; i++) {
             commandStream.QueueCommand(testNullCommand);
         }
@@ -57,7 +57,7 @@ public class StressTests_MayTakeLongToRun {
         int testLength = 100000000;
         int historyDepth = testLength / 10;
         CommandStream commandStream = new CommandStream(historyDepth);
-        Debug.Log($"current test settings: execute {nameof(testNullCommand)} {testLength} times, history recorded to a depth of {historyDepth}");
+        Debug.Log($"current test settings: execute {nameof(testNullCommand)} {testLength} times, history recorded to a depth of {historyDepth}, commands executed once all are queued");
         for (int i = 0; i < testLength; i++) {
             commandStream.QueueCommand(testNullCommand);
         }

--- a/Tests/EditorTests/StressTests.cs
+++ b/Tests/EditorTests/StressTests.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 using UnityEngine.TestTools;
 using SadSapphicGames.CommandPattern;
 
-public class StressTests {
+public class StressTests_MayTakeLongToRun {
 
     //? We use the same command object for all tests to save memory
     Command testNullCommand = new NullCommand();
@@ -22,7 +22,7 @@ public class StressTests {
         }
         commandStream.ExecuteFullQueue();
         Assert.IsTrue(commandStream.QueueEmpty);
-        //? at one hundred million test takes ~10 seconds (little bit less but thats the closest OOM)
+        //? at one hundred million test takes ~10 seconds
     }
     [Test, Timeout(300000)]
     public void VeryLargeNumberOfCommandsNoHistoryTest() {
@@ -37,6 +37,19 @@ public class StressTests {
         Assert.IsTrue(commandStream.QueueEmpty);
         //? at one hundred million test takes ~5 seconds
     }
+    [Test, Timeout(300000)]
+    public void IntMaxCommandsNoHistoryInLoopExecutionTest() {
+        //? As expected if the commands are executed as they are added to the queue and not stored in history we don't run out of memory and this test will run given enough time  
+        int testLength = int.MaxValue;
+        CommandStream commandStream = new CommandStream(0);
+        Debug.Log($"current test settings: execute {nameof(testNullCommand)} {testLength} times, no history recorded, commands executed as they enter queue.");
+        for (int i = 0; i < testLength; i++) {
+            commandStream.QueueCommand(testNullCommand);
+            commandStream.TryExecuteNext();
+        }
+        Assert.IsTrue(commandStream.QueueEmpty);
+        //? Executes in ~100 seconds (less but that closest order of magnitude)
+    }
     [Test, Timeout(30000)]
     public void VeryLargeNumberOfCommandsCappedHistoryTest() {
         //? this test has identified significant performance issues in DropHistory and must be run at a much smaller length
@@ -50,6 +63,6 @@ public class StressTests {
         }
         commandStream.ExecuteFullQueue();
         Assert.IsTrue(commandStream.QueueEmpty);
-        //? at one hundred million test takes ~5 seconds
+        //? at one hundred million test takes ~10 seconds
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name" : "com.sadsapphicgames.commandpattern",
-  "version" : "0.2.3",
+  "version" : "0.2.4",
   "displayName" : "Command Pattern",
   "description" : "This package contains a collection of classes and interfaces to allow for quick implementation of the command pattern across projects.",
   "author" : {


### PR DESCRIPTION
Adds methods to test that when history is not recorded, or is limited to a reasonable size, and commands are executed as soon as they are queues, there is no limit to the number of commands a CommandStream can execute given enough time (in both cases the test was able to execute int.maxvalue null commands in ~100 seconds with no immediately apparent optimizations to TryExecuteNext to reduce this). Also adds a test for ForceQueueUndo as well as a DropHistory method and test to verify its functionality. 

A note on optimizing TryExecuteNext to improve the runtime, I tried merging the return false ifs already but this made the code less readable and only improved the int.maxvalue commands runtime by an order of ~1 second so i discarded the changes.