### PR TITLE
0.3.0 update - package feature complete

### DIFF
--- a/Runtime/Commands/CommandStream.cs
+++ b/Runtime/Commands/CommandStream.cs
@@ -195,7 +195,14 @@ namespace SadSapphicGames.CommandPattern
             ) {
                 return false;
             }
-            nextCommand.Execute();
+            try {
+                nextCommand.Execute();
+            } catch (IrreversibleCompositeFailureException ex) {
+                throw ex;
+            } catch(ReversibleCompositeCommandException ex) {
+                Debug.LogWarning(ex.Message);
+                return false;
+            }
             if(historyDepth > 0) {
                 RecordCommand(nextCommand);
             }

--- a/Runtime/Commands/CommandStream.cs
+++ b/Runtime/Commands/CommandStream.cs
@@ -40,7 +40,7 @@ namespace SadSapphicGames.CommandPattern
         /// <returns>The history of executed commands, null if history is not recorded. </returns>
         public ReadOnlyCollection<Command> GetCommandHistory() {
             if(HistoryDepth == 0){
-                Debug.LogWarning("This CommandStream does no record its history");
+                Debug.LogWarning("This CommandStream does not record its history, returning null");
                 return null;
             }
             if(historyStartIndex == 0) {
@@ -73,10 +73,16 @@ namespace SadSapphicGames.CommandPattern
             } 
         }
         /// <summary>
-        /// This is the number of Commands currently stored in the CommandStreams history.
+        /// Gets the number of Commands currently recorded in the CommandStream's history.
         /// </summary>
         public int HistoryCount {
             get => commandHistory.Count;
+        }
+        /// <summary>
+        /// Gets the number of Commands currently waiting in the CommandStream's queue.
+        /// </summary>
+        public int QueueCount {
+            get => commandQueue.Count();
         }
 
         /// <summary>

--- a/Runtime/Commands/CommandStream.cs
+++ b/Runtime/Commands/CommandStream.cs
@@ -199,7 +199,7 @@ namespace SadSapphicGames.CommandPattern
                 nextCommand.Execute();
             } catch (IrreversibleCompositeFailureException ex) {
                 throw ex;
-            } catch(ReversibleCompositeCommandException ex) {
+            } catch(ReversibleCompositeFailureException ex) {
                 Debug.LogWarning(ex.Message);
                 return false;
             }

--- a/Runtime/Commands/CompositeCommand.cs
+++ b/Runtime/Commands/CompositeCommand.cs
@@ -10,7 +10,7 @@ namespace SadSapphicGames.CommandPattern {
     /// </summary>
     public abstract class CompositeCommand : Command {
         /// <summary>
-        /// The Commands that will be executed upon executing this object
+        /// The child Commands that will be executed upon executing this object
         /// </summary>
         protected List<Command> subCommands = new List<Command>();
         /// <summary>
@@ -35,7 +35,7 @@ namespace SadSapphicGames.CommandPattern {
         /// Executes each of the commands included in this object. 
         /// <remark> Default implementation queues all subCommands into the internalStream and executes them until it is empty.</remark>
         /// </summary>
-        /// <exception cref="CompositeFailureException"> Indicates one of the commands children failed, If this is possible you should be implementing IFailable to prevent this from happening. </exception>
+        /// <exception cref="CompositeFailureException"> Indicates one of the commands children failed, If this is possible you should be implementing IFailable. </exception>
         public override void Execute() {
             internalStream.QueueCommands(subCommands);
             Command prevChild;
@@ -49,7 +49,7 @@ namespace SadSapphicGames.CommandPattern {
     [System.Serializable]
     public class CompositeFailureException : System.Exception
     {
-        public CompositeFailureException(Command failedCommand) : base($"A CompositeCommand was executed however its child {failedCommand} failed. If you are seeing this you probably need to implement IFailable or your implementation of it contains an error.") { }
+        public CompositeFailureException(Command failedCommand) : base($"A CompositeCommand was executed however its child {failedCommand} failed. If you are seeing this your composite needs to implement IFailable or its implementation of IFailable.WouldFail contains an error.") { }
         public CompositeFailureException(string message) : base(message) { }
         public CompositeFailureException(string message, System.Exception inner) : base(message, inner) { }
         protected CompositeFailureException(

--- a/Runtime/Commands/CompositeCommand.cs
+++ b/Runtime/Commands/CompositeCommand.cs
@@ -32,29 +32,35 @@ namespace SadSapphicGames.CommandPattern {
         public int ChildCount { get => subCommands.Count; }
         
         /// <summary>
-        /// Queues all of the child commands into the internal CommandStream and attempts to invoke all of them. Will throw an exception if one of its children fails.
+        /// Queues all of the child commands into the internal CommandStream and attempts to invoke all of them. Will throw an exception if one of its children fails after attempting to revert all its executed commands.
         /// 
         /// Be aware that if you override this method you will bypass the implemented failsafe's for children of the CompositeCommand failing such as attempting to undo executed commands
         /// </summary>
-        /// <exception cref="IrreversibleCompositeFailureException"> Indicates one of the children of the CompositeCommand failed and its executed commands cannot be undone. TryExecuteNext will catch this exception and throw it upwards </exception>
-        /// <exception cref="ReversibleCompositeCommandException"> Indicates one of the children of the CompositeCommand failed but it was able to undo all of its executed commands. TryExecuteNext will catch this exception and handle it by returning false. </exception>
+        /// <exception cref="IrreversibleCompositeFailureException"> Indicates one of the children of the CompositeCommand failed and it executed one or more commands that cannot be undone. TryExecuteNext will catch this exception and throw it upwards </exception>
+        /// <exception cref="ReversibleCompositeFailureException"> Indicates one of the children of the CompositeCommand failed but it was able to undo all of its executed commands. TryExecuteNext will catch this exception and handle it by returning false. </exception>
         public override void Execute() {
             internalStream.QueueCommands(subCommands);
             Command prevChild;
             while(internalStream.TryExecuteNext(out prevChild)) {}
             if(prevChild != null) { //? One of the children failed 
-                var canUndo =
+                var reversibleCommands =
                     from com in internalStream.GetCommandHistory()
-                    select com is IUndoable;
-                if(canUndo.Contains(false)) {
-                    throw new IrreversibleCompositeFailureException(prevChild);
+                    where com is IUndoable
+                    select com;
+                var irreversibleCommands = 
+                    from com in internalStream.GetCommandHistory()
+                    where com is not IUndoable
+                    select com;
+                internalStream.DropQueue();
+                foreach (var command in reversibleCommands) {
+                    internalStream.ForceQueueUndoCommand((IUndoable)command);
+                }
+                internalStream.ExecuteFullQueue();
+
+                if(irreversibleCommands.Count() == 0) {
+                    throw new ReversibleCompositeFailureException(prevChild);
                 } else {
-                    internalStream.DropQueue();
-                    foreach (var command in internalStream.GetCommandHistory()) {
-                        internalStream.ForceQueueUndoCommand((IUndoable)command);
-                    }
-                    internalStream.ExecuteFullQueue();
-                    throw new ReversibleCompositeCommandException(prevChild);
+                    throw new IrreversibleCompositeFailureException(prevChild,irreversibleCommands.ToList());
                 }
             }
         }
@@ -65,24 +71,33 @@ namespace SadSapphicGames.CommandPattern {
     [System.Serializable]
     public class IrreversibleCompositeFailureException : System.Exception
     {
-        public IrreversibleCompositeFailureException(Command failedCommand) : base($"A CompositeCommand was executed however its child {failedCommand} failed and the composite could not undo its executed commands") { }
-        public IrreversibleCompositeFailureException(string message) : base(message) { }
-        public IrreversibleCompositeFailureException(string message, System.Exception inner) : base(message, inner) { }
-        protected IrreversibleCompositeFailureException(
-            System.Runtime.Serialization.SerializationInfo info,
-            System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
+        /// <summary>
+        /// The child command that failed
+        /// </summary>
+        Command failedCommand;
+        /// <summary>
+        /// The executed commands that could not be undone
+        /// </summary>
+        List<Command> irreversibleCommands;
+        public IrreversibleCompositeFailureException(Command failedCommand, List<Command> irreversibleCommands) 
+        : base($"A CompositeCommand was executed however its child {failedCommand} failed, {irreversibleCommands.Count} executed children could not be undone") {
+            this.failedCommand = failedCommand;
+            this.irreversibleCommands = irreversibleCommands;
+        }
     }
     /// <summary>
     /// An exception that indicates a CompositeCommand is executed but one of its children failed, however the composite was able to undo the commands it had executed
     /// </summary>
     [System.Serializable]
-    public class ReversibleCompositeCommandException : System.Exception
+    public class ReversibleCompositeFailureException : System.Exception
     {
-        public ReversibleCompositeCommandException(Command failedCommand) : base($"A CompositeCommand was executed however its child {failedCommand} failed, the executed commands where able to be undone") { }
-        public ReversibleCompositeCommandException(string message) : base(message) { }
-        public ReversibleCompositeCommandException(string message, System.Exception inner) : base(message, inner) { }
-        protected ReversibleCompositeCommandException(
-            System.Runtime.Serialization.SerializationInfo info,
-            System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
+        /// <summary>
+        /// The child command that failed
+        /// </summary>
+        Command failedCommand;
+        public ReversibleCompositeFailureException(Command failedCommand) 
+        : base($"A CompositeCommand was executed however its child {failedCommand} failed, all executed children where able to be undone") {
+            this.failedCommand = failedCommand;
+        }
     }
 }

--- a/Tests/EditorTests/BadCompositeCommand.cs
+++ b/Tests/EditorTests/BadCompositeCommand.cs
@@ -17,7 +17,7 @@ public class BadCompositeCommandReversible : CompositeCommand
 public class BadCompositeCommandIrreversible : CompositeCommand
 {
     public BadCompositeCommandIrreversible() {
-        AddChild(new IrreversibleCommand());
+        AddChild(new IrreversibleNullCommand());
         AddChild(new AlwaysFailsCommand());
     }
 }

--- a/Tests/EditorTests/BadCompositeCommand.cs
+++ b/Tests/EditorTests/BadCompositeCommand.cs
@@ -4,12 +4,20 @@ using SadSapphicGames.CommandPattern;
 using UnityEngine;
 
 /// <summary>
-/// A CompositeCommand who's children will quietly fail (It does not implement IFailable). This should never be used outside of tests. It will always cause an exception.
+/// A CompositeCommand who's children will quietly fail (It does not implement IFailable) but who can be reverted
 /// </summary>
-public class BadCompositeCommand : CompositeCommand
+public class BadCompositeCommandReversible : CompositeCommand
 {
-    public BadCompositeCommand() {
+    public BadCompositeCommandReversible() {
         AddChild(new NullCommand());
+        AddChild(new AlwaysFailsCommand());
+    }
+}
+
+public class BadCompositeCommandIrreversible : CompositeCommand
+{
+    public BadCompositeCommandIrreversible() {
+        AddChild(new IrreversibleCommand());
         AddChild(new AlwaysFailsCommand());
     }
 }

--- a/Tests/EditorTests/CommandStreamTests.cs
+++ b/Tests/EditorTests/CommandStreamTests.cs
@@ -16,6 +16,7 @@ public class CommandStreamTests {
             commands[i] = new NullCommand();
         }
         commandStream.QueueCommands(commands);
+        Assert.AreEqual(expected: testDepth, actual: commandStream.QueueCount);
         int j = 0;
         while(commandStream.TryExecuteNext()) {
             Assert.AreEqual(
@@ -25,6 +26,7 @@ public class CommandStreamTests {
             Assert.IsTrue(j <= testDepth);
             j++;
         }
+        Assert.IsTrue(commandStream.QueueEmpty);
     }
     [Test]
     public void CommandStreamTickerTest() {
@@ -81,6 +83,16 @@ public class CommandStreamTests {
             }
             Assert.AreEqual(expected: testDepth * 2, actual: j);
         }
+    }
+    [Test]
+    public void CommandStreamNoHistoryTest() {
+        const int testLength = 10;
+        CommandStream commandStream = new CommandStream(0);
+        for (int i = 0; i < testLength; i++) {
+            commandStream.QueueCommand(new NullCommand());
+            Assert.IsTrue(commandStream.TryExecuteNext());
+        }
+        Assert.IsNull(commandStream.GetCommandHistory());
     }
     [Test]
     public void DropQueueTest() {

--- a/Tests/EditorTests/CompositeCommandTest.cs
+++ b/Tests/EditorTests/CompositeCommandTest.cs
@@ -20,7 +20,7 @@ public class CompositeCommandTest
         Assert.AreEqual(expected: 20, actual: testComposite.ChildCount);
     }
     [Test]
-    public void CompositeCommandTickerTest() {
+    public void SimpleCompositeCommandTickerTest() {
         CommandStream commandStream = new CommandStream();
         Ticker ticker = new Ticker();
         List<Command> subCommands = new List<Command>();

--- a/Tests/EditorTests/CompositeCommandTest.cs
+++ b/Tests/EditorTests/CompositeCommandTest.cs
@@ -35,13 +35,25 @@ public class CompositeCommandTest
         Assert.AreEqual(expected: testSize, actual: ticker.count);
     }
     [Test]
-    public void CompositeFailureExceptionTest() {
+    public void CompositeFailureReversibleTest() {
         CommandStream commandStream = new CommandStream();
-        BadCompositeCommand testComposite = new BadCompositeCommand();
+        BadCompositeCommandReversible testComposite = new BadCompositeCommandReversible();
         commandStream.QueueCommand(testComposite);
         //? uncomment To test the error readout (will make test fail)
         // commandStream.TryExecuteNext();
-        Assert.Throws<CompositeFailureException>(() => {
+        Assert.DoesNotThrow(() => {
+            commandStream.TryExecuteNext();
+        });
+        Assert.AreEqual(expected: 0, actual: commandStream.HistoryCount);
+    }
+    [Test]
+    public void CompositeFailureIrreversibleTest() {
+        CommandStream commandStream = new CommandStream();
+        BadCompositeCommandIrreversible testComposite = new BadCompositeCommandIrreversible();
+        commandStream.QueueCommand(testComposite);
+        //? uncomment To test the error readout (will make test fail)
+        // commandStream.TryExecuteNext();
+        Assert.Throws<IrreversibleCompositeFailureException>(() => {
             commandStream.TryExecuteNext();
         });
     }

--- a/Tests/EditorTests/IFailableTests.cs
+++ b/Tests/EditorTests/IFailableTests.cs
@@ -16,6 +16,7 @@ public class IFailableTests
         Assert.IsFalse(commandStream.TryExecuteNext(out Command nextCommand));
         Assert.IsNotNull(nextCommand);
         Assert.AreEqual(expected: 0, actual: commandStream.HistoryCount);
+        Assert.AreEqual(expected: 0, actual: commandStream.QueueCount);
     }
     [Test]
     public void SimpleCompositeFailureTest() {

--- a/Tests/EditorTests/IrreversibleCommand.cs
+++ b/Tests/EditorTests/IrreversibleCommand.cs
@@ -2,7 +2,7 @@ using SadSapphicGames.CommandPattern;
 /// <summary>
 /// A mockup of a command that does not implement IUndoable, aside from that identical to NullCommand
 /// </summary>
-public class IrreversibleCommand : Command {
+public class IrreversibleNullCommand : Command {
     /// <summary>
     /// Does nothing
     /// </summary>

--- a/Tests/EditorTests/IrreversibleCommand.cs
+++ b/Tests/EditorTests/IrreversibleCommand.cs
@@ -1,0 +1,11 @@
+using SadSapphicGames.CommandPattern;
+/// <summary>
+/// A mockup of a command that does not implement IUndoable, aside from that identical to NullCommand
+/// </summary>
+public class IrreversibleCommand : Command {
+    /// <summary>
+    /// Does nothing
+    /// </summary>
+    public override void Execute() { 
+    }
+}

--- a/Tests/EditorTests/IrreversibleCommand.cs.meta
+++ b/Tests/EditorTests/IrreversibleCommand.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5e22f9fc07319494b9f028b69b18b9d4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/PlayModeTests/CommandManagerTests.cs
+++ b/Tests/PlayModeTests/CommandManagerTests.cs
@@ -34,4 +34,21 @@ public class CommandManagerTests
             actual: CommandManagerInstance.HistoryCount
         );
     }
+    [UnityTest]
+    public IEnumerator CommandManagerFreezeExecutionTest()
+    {
+        CommandManagerInstance.ToggleCommandExecution(false);
+        CommandManagerInstance.QueueCommand(new NullCommand());
+        yield return new WaitForEndOfFrame();
+        yield return new WaitForEndOfFrame();
+        Assert.IsFalse(CommandManagerInstance.QueueEmpty);
+        CommandManagerInstance.ToggleCommandExecution(true);
+        yield return new WaitForEndOfFrame();
+        yield return new WaitForEndOfFrame();
+        Assert.IsTrue(CommandManagerInstance.QueueEmpty);
+        Assert.AreEqual(
+            expected: 1,
+            actual: CommandManagerInstance.HistoryCount
+        );
+    }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name" : "com.sadsapphicgames.commandpattern",
-  "version" : "0.2.4",
+  "version" : "0.3.0",
   "displayName" : "Command Pattern",
   "description" : "This package contains a collection of classes and interfaces to allow for quick implementation of the command pattern across projects.",
   "author" : {


### PR DESCRIPTION
Adds some polish to test various functionality that wasn't captured by any existing tests as well as exception handling for children of an executed composite command failing. Upon one of its children failing the composite will no undo all of its executed children that implement IUndoable. If there are no executed children that do not implement IUndoable it will throw an exception to TryExecuteNext indicating it failed but was able to reverse itself. In this case the exception will be considered handled an TryExecuteNext will return false with a warning. If it executed any command that it cannot undo it will throw a different exception indicating it could not fully reverse itself to TryExecuteNext, which will catch it and throw it upwards to be handled by its wrapper. The exception will have a list of executed children that could not be undone so that the wrapper can determine what to do with them. SingletonCommandManager does not handle this exception as this situation should really be avoided in the first place if at all possible and the details of handling it would depend on the implementation of the irreversible commands. If it cannot be avoided the end user should really be implementing their own CommandStream wrapper to handle it rather than using the out-of-the-box wrapper. 